### PR TITLE
added early stopped to shell scripts

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -6,6 +6,9 @@
 # https://hjdskes.github.io/blog/update-deploying-hugo-on-personal-github-pages/
 # for more information.
 
+# failure is a natural part of life
+set -e
+
 # Set the English locale for the `date` command.
 export LC_TIME=en_US.UTF-8
 

--- a/setup.sh
+++ b/setup.sh
@@ -7,6 +7,9 @@
 # # https://hjdskes.github.io/blog/update-deploying-hugo-on-personal-github-pages/
 # # for more information.
 # 
+# # failure is a natural part of life
+# set -e
+#
 # # Name of the branch containing the Hugo source files.
 # SOURCE=hugo
 # 


### PR DESCRIPTION
Hi! I clicked into this project after hearing @angela-li talk about it at `#satRdays`. I wanted to make a tiny contribution, hope you'll consider this!

As written, the shell scripts in this project will keep running even if an early command fails. This can often have unexpected and weird effects, so I propose adding a `set -e` ([I do this in every shell script I write](https://github.com/jameslamb/doppel-cli/blob/master/publish.sh#L3)) so the script will stop immediately if anything fails.